### PR TITLE
Add "All" keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For each webform that you want to save the signature to an activity you need:
 * One or more fields of type `esign` (one per signature needed).
 * A field with name: `esign_custom_field`; type: `hidden`; value: A comma-delimited list of custom field names (e.g., `custom_1` or `custom_1,custom_2`). If multiple custom fields are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.
 * A field with name: `esign_entity`; type: `hidden`; value: A comma-delimited list of entities (e.g., `Activity` or `Activity,Participant`). If multiple entities are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.
-* A field with name: `esign_entity_type_id`; type: `hidden`; value: A comma-delimited list of Activity Type IDs (for Activities and Cases) or Event IDs(for Participants). If multiple entitiy IDs are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.
+* A field with name: `esign_entity_type_id`; type: `hidden`; value: A comma-delimited list of Activity Type IDs (for Activities and Cases) or Event IDs(for Participants). If multiple entitiy IDs are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.  You can also specify `All` instead of an entity ID; in that case, all records of this entity type will receive the signature.
 * Make sure CiviCRM processing is enabled on the webform and that you have added at least one activity/and or event registration of the type(s) you specified in `esign_entity_type_id` field.
 
 Optionally, file the activity on a case by enabling a Case within the CiviCRM processing and setting the Activity to "File on Case".
@@ -48,6 +48,8 @@ Optionally, file the activity on a case by enabling a Case within the CiviCRM pr
 |Two custom fields on a single activity|custom_9,custom_10|Activity,Activity|70,70|Note that the same activity_type_id is given twice|
 |Different custom fields on different activities (different types)|custom_9,custom_10|Activity,Activity|70,71||
 |An activity and a participant|custom_9,custom_10|Activity,Participant|70,3|activity_type_id for activity, event_id for participant|
+|All new activities|custom_9|Activity|All||
+|All participant records and a "meeting" activity|custom_10,custom_9|Participant,Activity|All,1||
 
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -27,25 +27,29 @@ For each webform that you want to save the signature to an activity you need:
 
 #### On each webform:
 
-* A field of type `esign`.
-* A field with name: `esign_custom_field`; type: `hidden`; value: A comma-delimited list of custom field names (e.g., `custom_1` or `custom_1,custom_2`). If multiple custom fields are named, they must be listed in the same order as the activities configured on the CiviCRM tab of the webform. See _[Setup Examples](#setup-examples)_ below.
-* A field with name: `esign_activity_type_id`; type: `hidden`; value: A comma-delimited list of Activiy Type IDs. If multiple IDs are named, they must be listed in the same order as the activities configured on the CiviCRM tab of the webform. See _[Setup Examples](#setup-examples)_ below.
-* Make sure CiviCRM processing is enabled on the webform and that you have added at least one activity of the type(s) you specified in `esign_activity_type_id` field.
+* One or more fields of type `esign` (one per signature needed).
+* A field with name: `esign_custom_field`; type: `hidden`; value: A comma-delimited list of custom field names (e.g., `custom_1` or `custom_1,custom_2`). If multiple custom fields are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.
+* A field with name: `esign_entity`; type: `hidden`; value: A comma-delimited list of entities (e.g., `Activity` or `Activity,Participant`). If multiple entities are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.
+* A field with name: `esign_entity_type_id`; type: `hidden`; value: A comma-delimited list of Activity Type IDs (for Activities and Cases) or Event IDs(for Participants). If multiple entitiy IDs are specified, they will correspond to the signature fields in the order you add them to the form.  See _[Setup Examples](#setup-examples)_ below.
+* Make sure CiviCRM processing is enabled on the webform and that you have added at least one activity/and or event registration of the type(s) you specified in `esign_entity_type_id` field.
 
 Optionally, file the activity on a case by enabling a Case within the CiviCRM processing and setting the Activity to "File on Case".
 
 * Filenames will be created in the format "sig_20191119000000_firstnamelastname.png" if civicrm firstname/lastname fields are found.  If not name will be omitted.
-* esign_custom_field and esign_activity_type_id will not be shown in emails / submission views.
+* The hidden fields added above will not be shown in emails / submission views.
 
 ##### Setup Examples
 
-|Use case|`esign_custom_field`<br />example|`esign_activity_type_id`<br />example|notes|
+|Use case|`esign_custom_field`<br />example|`esign_entity`<br />example|`esign_entity_id`<br />example|notes|
 |---|---|---|---|
-|A single custom field on a single activity|custom_9|70||
-|A single custom field on multiple activities (must be different types)|custom_9,custom_9|70,71||
-|Two custom fields on a single activity|custom_9,custom_10|70,70|Note that the same activity_type_id is given twice|
-|Different custom fields on different activities (different types)|custom_9,custom_10|70,71||
+|A single custom field on a single activity|custom_9|Activity|70||
+|A single custom field on a single activity|custom_9|Participant|3||
+|A single custom field on multiple activities (must be different types)|custom_9,custom_9|Activity,Activity|70,71||
+|Two custom fields on a single activity|custom_9,custom_10|Activity,Activity|70,70|Note that the same activity_type_id is given twice|
+|Different custom fields on different activities (different types)|custom_9,custom_10|Activity,Activity|70,71||
+|An activity and a participant|custom_9,custom_10|Activity,Participant|70,3|activity_type_id for activity, event_id for participant|
+
 
 ## Known issues
 
-* Due to a technical quirk, this module does not support attaching signatures to multiple activities of the same activity type in one form. Please submit an issue if you're interested in addressing this limitation.
+* Due to a technical quirk, this module does not support attaching signatures to multiple activities of the same activity type/event in one form. Please submit an issue if you're interested in addressing this limitation.

--- a/webform_civicrm_esign.module
+++ b/webform_civicrm_esign.module
@@ -11,6 +11,10 @@ function webform_civicrm_esign_civicrm_post($op, $name, $id, $dao) {
     case 'Activity':
       $values['activity_id'][$dao->activity_type_id] = $id;
       break;
+
+    case 'Participant':
+      $values['participant_id'][$dao->event_id] = (int) $id;
+      break;
   }
 }
 
@@ -25,8 +29,8 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
   civicrm_initialize();
   global $values;
 
-  //We will potentially be collecting multiple components
-  $componentArray = array();
+  // We will potentially be collecting multiple signatures.
+  $componentArray = [];
 
   if (!$node->type == 'webform') {
     return;
@@ -40,13 +44,25 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
 
     $dataKeys[$componentDetail['form_key']] = $componentKey;
   }
-  if (empty($componentArray) || empty($dataKeys['esign_custom_field']) || empty($dataKeys['esign_activity_type_id'])) {
-    watchdog('webform_civicrm_esign', 'One of esign, esign_custom_field, esign_activity_type_id fields were not found');
-    return;
+
+  // Support legacy "esign_activity_type_id" field by converting to the new format.
+  if (!empty($dataKeys['esign_activity_type_id'])) {
+    if (!empty($dataKeys['esign_entity']) || !empty($dataKeys['esign_entity_type_id'])) {
+      watchdog('webform_civicrm_esign', 'Your webform can not contain both "esign_activity_type_id" and the "esign_entity" or "esign_entity_type_id" fields.');
+    }
+    $entityArr = array_fill(0, count($componentArray), 'Activity');
+    $entityTypeIdArr = explode(',', reset($submission->data[$dataKeys['esign_activity_type_id']]));
   }
-  //Define our potential arrays of custom field and activity ID combinations (Manually wired by following readme as per other module configs)
+
+  if (empty($componentArray) || empty($dataKeys['esign_custom_field']) || empty($dataKeys['esign_entity']) || empty($dataKeys['esign_entity_id'])) {
+    watchdog('webform_civicrm_esign', 'One of esign, esign_custom_field, esign_entity or esign_entity_id fields were not found');
+  }
+  //Define our potential arrays of entity, entity_type_id, and custom field combinations (Manually wired by following readme as per other module configs)
   $customFieldArr = explode(',', reset($submission->data[$dataKeys['esign_custom_field']]));
-  $activityTypeArr = explode(',', reset($submission->data[$dataKeys['esign_activity_type_id']]));
+  if (!isset($entityArr)) {
+    $entityArr = explode(',', reset($submission->data[$dataKeys['esign_entity']]));
+    $entityTypeIdArr = explode(',', reset($submission->data[$dataKeys['esign_entity_type_id']]));
+  }
 
   foreach ($componentArray as $caKey => $esignComponentId) {
     // split the string on commas
@@ -57,8 +73,10 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
     $image = base64_decode($data[1]);
     //Get the correct custom file field from a potential array of field IDs
     $customfield = $customFieldArr[$caKey];
-    //Get the correct activity type ID from a potential array of type IDs
-    $activityTypeId = $activityTypeArr[$caKey];
+    //Get the correct entity ID from a potential array of entity IDs
+    $entityTypeId = $entityTypeIdArr[$caKey];
+    //Get the correct entity ID from a potential array of entities
+    $entity = $entityArr[$caKey];
     // Generate a suitable filename (sig_20170101000000_joe_bloggs.png)
     $firstName = CRM_Utils_Array::value(CRM_Utils_Array::value('civicrm_1_contact_1_contact_first_name', $dataKeys), $submission->data, NULL);
     $lastName = CRM_Utils_Array::value(CRM_Utils_Array::value('civicrm_1_contact_1_contact_last_name', $dataKeys), $submission->data, NULL);
@@ -68,18 +86,19 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
     $datestamp = date('YmdHis');
     $filename = 'sig_' . $datestamp . $fullName . '.png';
 
-    if (array_key_exists($activityTypeId, $values['activity_id'])) {
-      $activityId = $values['activity_id'][$activityTypeId];
+    $valueKey = strtolower($entity) . '_id';
+    if (array_key_exists($entityTypeId, $values[$valueKey])) {
+      $entityId = $values[$valueKey][$entityTypeId];
     }
     else {
-      watchdog('webform_civicrm_esign', 'ERROR: Activity ID not found - you need to add an activity in the webform_civicrm configuration.');
+      watchdog('webform_civicrm_esign', 'ERROR: Entity ID not found - your webform_civicrm configuration must have an entity and entity ID corresponding to your esign_entity and esign_entity_id values.');
       return;
     }
 
     // Create an attachment for a custom file field
     $attachmentParams = array(
       'field_name' => $customfield,
-      'entity_id' => $activityId,
+      'entity_id' => $entityId,
       'name' => $filename,
       'mime_type' => 'image/png',
       'content' => $image,

--- a/webform_civicrm_esign.module
+++ b/webform_civicrm_esign.module
@@ -80,22 +80,27 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
     $filename = webform_civicrm_esign_generateFilename($dataKeys, $submission);
     $valueKey = strtolower($entity) . '_id';
     if (array_key_exists($entityTypeId, $values[$valueKey])) {
-      $entityId = $values[$valueKey][$entityTypeId];
+      $entityIds[0] = $values[$valueKey][$entityTypeId];
     }
-    else {
+    if ($entityTypeId == 'All') {
+      $entityIds = $values[$valueKey];
+    }
+    if (!$entityIds) {
       watchdog('webform_civicrm_esign', 'ERROR: Entity ID not found - your webform_civicrm configuration must have an entity and entity ID corresponding to your esign_entity and esign_entity_id values.');
       return;
     }
 
-    // Create an attachment for a custom file field
-    $attachmentParams = array(
-      'field_name' => $customfield,
-      'entity_id' => $entityId,
-      'name' => $filename,
-      'mime_type' => 'image/png',
-      'content' => $image,
-    );
-    civicrm_api3('Attachment', 'create', $attachmentParams);
+    foreach ($entityIds as $entityId) {
+      // Create an attachment for a custom file field
+      $attachmentParams = array(
+        'field_name' => $customfield,
+        'entity_id' => $entityId,
+        'name' => $filename,
+        'mime_type' => 'image/png',
+        'content' => $image,
+      );
+      civicrm_api3('Attachment', 'create', $attachmentParams);
+    }
   }
   return;
 }

--- a/webform_civicrm_esign.module
+++ b/webform_civicrm_esign.module
@@ -77,15 +77,7 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
     $entityTypeId = $entityTypeIdArr[$caKey];
     //Get the correct entity ID from a potential array of entities
     $entity = $entityArr[$caKey];
-    // Generate a suitable filename (sig_20170101000000_joe_bloggs.png)
-    $firstName = CRM_Utils_Array::value(CRM_Utils_Array::value('civicrm_1_contact_1_contact_first_name', $dataKeys), $submission->data, NULL);
-    $lastName = CRM_Utils_Array::value(CRM_Utils_Array::value('civicrm_1_contact_1_contact_last_name', $dataKeys), $submission->data, NULL);
-    $firstName = reset($firstName);
-    $lastName = reset($lastName);
-    empty($firstName . $lastName) ? $fullName = '' : $fullName = '_' . $firstName . $lastName;
-    $datestamp = date('YmdHis');
-    $filename = 'sig_' . $datestamp . $fullName . '.png';
-
+    $filename = webform_civicrm_esign_generateFilename($dataKeys, $submission);
     $valueKey = strtolower($entity) . '_id';
     if (array_key_exists($entityTypeId, $values[$valueKey])) {
       $entityId = $values[$valueKey][$entityTypeId];
@@ -106,6 +98,20 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
     civicrm_api3('Attachment', 'create', $attachmentParams);
   }
   return;
+}
+
+/**
+ * Generate a suitable filename (sig_20170101000000_joe_bloggs.png)
+ */
+function webform_civicrm_esign_generateFilename(array $dataKeys, stdClass $submission) : string {
+  $firstName = CRM_Utils_Array::value(CRM_Utils_Array::value('civicrm_1_contact_1_contact_first_name', $dataKeys), $submission->data, NULL);
+  $lastName = CRM_Utils_Array::value(CRM_Utils_Array::value('civicrm_1_contact_1_contact_last_name', $dataKeys), $submission->data, NULL);
+  $firstName = reset($firstName);
+  $lastName = reset($lastName);
+  empty($firstName . $lastName) ? $fullName = '' : $fullName = '_' . $firstName . $lastName;
+  $datestamp = date('YmdHis');
+  $filename = 'sig_' . $datestamp . $fullName . '.png';
+  return $filename;
 }
 
 /**


### PR DESCRIPTION
This builds upon my previous PR, which should be merged before this one, if you merge any!  This lets you use "All" in place of an activity ID or participant ID.  The signature will be added to all records of the corresponding entity created by this webform submission.

My use case here is a webform that allows participants to sign a liability waiver.  The event it applies to is a "User Select" field, showing all future events.  The ability to add a signature for multiple events is less important than the ability to create a form that doesn't need event IDs updated when new events are added to Civi.