### PR TITLE
Add null coalescing operator when checking `array_key_exists()`

### DIFF
--- a/webform_civicrm_esign.module
+++ b/webform_civicrm_esign.module
@@ -79,7 +79,7 @@ function webform_civicrm_esign_webform_submission_insert($node, $submission) {
     $entity = $entityArr[$caKey];
     $filename = webform_civicrm_esign_generateFilename($dataKeys, $submission);
     $valueKey = strtolower($entity) . '_id';
-    if (array_key_exists($entityTypeId, $values[$valueKey])) {
+    if (array_key_exists($entityTypeId, ($values[$valueKey] ?? []))) {
       $entityIds[0] = $values[$valueKey][$entityTypeId];
     }
     if ($entityTypeId == 'All') {


### PR DESCRIPTION
Overview
A TypeError can occur, rather then the desired/more informative WatchDog error, if an array key is not found when passing in `$values[$valueKey]`.

Before
```
TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in webform_civicrm_esign_webform_submission_insert() (line 82 of /[webroot]/sites/all/modules/webform_civicrm_esign/webform_civicrm_esign.module).
```

After
By adding a null coalescing operator, the code path will continue even if `$values` is an empty array, in which case `$entityIds` will be null and the code will reach the intended error that will give the user more troubleshooting information.